### PR TITLE
先頭BOMに対する対応

### DIFF
--- a/app/Models/AddonAnalyzer.php
+++ b/app/Models/AddonAnalyzer.php
@@ -81,6 +81,8 @@ class AddonAnalyzer
 
   private static function prepareDat($content)
   {
+    //先頭のBOMを削除
+    $content = preg_replace('/^\xEF\xBB\xBF/', '', $content);
     // 区切り文字を--に統一
     $content = preg_replace('/\-{3,}/', '--', $content);
     // 改行コードを統一


### PR DESCRIPTION
dat・tabファイルのテキスト先頭にBOM（EF BB BF）がある場合、正しく処理できない問題を修正しました。
ご対応の程、宜しくお願い致します。